### PR TITLE
added switch between settlement as close and last price, necessary in futures.

### DIFF
--- a/tvDatafeed/main.py
+++ b/tvDatafeed/main.py
@@ -193,6 +193,7 @@ class TvDatafeed:
         n_bars: int = 10,
         fut_contract: int = None,
         extended_session: bool = False,
+        settlement_as_close: bool = True,
     ) -> pd.DataFrame:
         """get historical data
 
@@ -263,6 +264,8 @@ class TvDatafeed:
                 + symbol
                 + '","adjustment":"splits","session":'
                 + ('"regular"' if not extended_session else '"extended"')
+                + ',"settlement-as-close":'
+                + ('false' if not settlement_as_close else 'true')                
                 + "}",
             ],
         )


### PR DESCRIPTION
I've implemented the ability to choose between SET price, which is on by default in Tradingview, and last closing price, which wasn't accessible before.